### PR TITLE
fix: recover from time.AfterFunc panic

### DIFF
--- a/sqlx-runner/tx.go
+++ b/sqlx-runner/tx.go
@@ -37,14 +37,8 @@ func WrapSqlxTx(tx *sqlx.Tx) *Tx {
 	newtx := &Tx{Tx: tx, Queryable: &Queryable{tx}}
 	if dat.Strict {
 		time.AfterFunc(1*time.Minute, func() {
-			defer func() {
-				if r := recover(); r != nil {
-					fmt.Printf("recovered dat error: %s", r)
-				}
-			}()
-
 			if !newtx.IsRollbacked && newtx.state == txPending {
-				panic("A database transaction was not closed!")
+				fmt.Println("A database transaction was not closed!")
 			}
 		})
 	}

--- a/sqlx-runner/tx.go
+++ b/sqlx-runner/tx.go
@@ -38,7 +38,7 @@ func WrapSqlxTx(tx *sqlx.Tx) *Tx {
 	if dat.Strict {
 		time.AfterFunc(1*time.Minute, func() {
 			if !newtx.IsRollbacked && newtx.state == txPending {
-				fmt.Println("A database transaction was not closed!")
+				fmt.Println("a database transaction is still open after one minute")
 			}
 		})
 	}


### PR DESCRIPTION
Sometimes, API transactions are taking more than 1 minute to timeout, causing the `dat` transaction to panic. This unrecovered panic, when happening across multiple pods, can kill all of them and leave us without any pods to serve requests.

Bear in mind the correct way to fix this is by using the context or refactoring the whole `dat` package. Or really stop using the `dat` package.
